### PR TITLE
add -fsanitize=address for debug gcc& cland debug builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,7 +49,7 @@ IF (CMAKE_C_COMPILER_ID STREQUAL GNU
         IF (CMAKE_BUILD_TYPE STREQUAL Release)
             SET(MY_CMAKE_FLAGS "${MY_CMAKE_FLAGS} -g0 -O3")
         ELSE()
-            SET(MY_CMAKE_FLAGS "${MY_CMAKE_FLAGS} -g3 -O0")
+            SET(MY_CMAKE_FLAGS "${MY_CMAKE_FLAGS} -g3 -O0 -fsanitize=address")
         ENDIF()
 ENDIF()
 


### PR DESCRIPTION
-fsanitize=address is a great feature to check memory leaks and memory corruption.
if I remove lshpack_enc_cleanup(&henc); call or lshpack_dec_cleanup(&hdec); call from e.g test_hpack_test_RFC_Example function 
make test will fail
then to analyze this issue further I'll run ./test/test_hpack from command line and get following report

=================================================================
==6015==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 512 byte(s) in 1 object(s) allocated from:
    #0 0x7f1541dd6b50 in __interceptor_malloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xdeb50)
    #1 0x55c222909fcb in henc_grow_tables /tmp/ls-hpack/src/lshpack.c:71443
    #2 0x55c22290aa0e in lshpack_enc_push_entry /tmp/ls-hpack/src/lshpack.c:71493
    #3 0x55c22290bde0 in lshpack_enc_encode /tmp/ls-hpack/src/lshpack.c:71663
    #4 0x55c2228f19b3 in test_hpack_test_RFC_Example /tmp/ls-hpack/test/test_hpack.c:353
    #5 0x55c2228fd54e in main /tmp/ls-hpack/test/test_hpack.c:1455
    #6 0x7f1541928b96 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21b96)

Indirect leak of 114 byte(s) in 1 object(s) allocated from:
    #0 0x7f1541dd6b50 in __interceptor_malloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xdeb50)
    #1 0x55c22290aa39 in lshpack_enc_push_entry /tmp/ls-hpack/src/lshpack.c:71497
    #2 0x55c22290bde0 in lshpack_enc_encode /tmp/ls-hpack/src/lshpack.c:71663
    #3 0x55c2228f1d86 in test_hpack_test_RFC_Example /tmp/ls-hpack/test/test_hpack.c:385
    #4 0x55c2228fd54e in main /tmp/ls-hpack/test/test_hpack.c:1455
    #5 0x7f1541928b96 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21b96)

Indirect leak of 81 byte(s) in 1 object(s) allocated from:
    #0 0x7f1541dd6b50 in __interceptor_malloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xdeb50)
    #1 0x55c22290aa39 in lshpack_enc_push_entry /tmp/ls-hpack/src/lshpack.c:71497
    #2 0x55c22290bde0 in lshpack_enc_encode /tmp/ls-hpack/src/lshpack.c:71663
    #3 0x55c2228f1c99 in test_hpack_test_RFC_Example /tmp/ls-hpack/test/test_hpack.c:376
    #4 0x55c2228fd54e in main /tmp/ls-hpack/test/test_hpack.c:1455
    #5 0x7f1541928b96 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21b96)

Indirect leak of 68 byte(s) in 1 object(s) allocated from:
    #0 0x7f1541dd6b50 in __interceptor_malloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xdeb50)
    #1 0x55c22290aa39 in lshpack_enc_push_entry /tmp/ls-hpack/src/lshpack.c:71497
    #2 0x55c22290bde0 in lshpack_enc_encode /tmp/ls-hpack/src/lshpack.c:71663
    #3 0x55c2228f1d37 in test_hpack_test_RFC_Example /tmp/ls-hpack/test/test_hpack.c:382
    #4 0x55c2228fd54e in main /tmp/ls-hpack/test/test_hpack.c:1455
    #5 0x7f1541928b96 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21b96)

SUMMARY: AddressSanitizer: 775 byte(s) leaked in 4 allocation(s).


the same way if I add 
char a[100];
a[100] = 0;
in test and run test I'll get following report

==6199==ERROR: AddressSanitizer: stack-buffer-overflow on address 0x7ffde959c1d4 at pc 0x55df88acc554 bp 0x7ffde959be20 sp 0x7ffde959be10
WRITE of size 1 at 0x7ffde959c1d4 thread T0
    #0 0x55df88acc553 in test_hpack_test_RFC_Example /tmp/ls-hpack/test/test_hpack.c:457
    #1 0x55df88ad759f in main /tmp/ls-hpack/test/test_hpack.c:1456
    #2 0x7fcd2b090b96 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21b96)
    #3 0x55df88aca3b9 in _start (/tmp/ls-hpack/test/test_hpack+0xb3b9)

Address 0x7ffde959c1d4 is located in stack of thread T0 at offset 836 in frame
    #0 0x55df88acb4b4 in test_hpack_test_RFC_Example /tmp/ls-hpack/test/test_hpack.c:320

  This frame has 11 object(s):
    [32, 36) 'name_len'
    [96, 100) 'val_len'
    [160, 168) 'pSrc'
    [224, 264) 'hdec'
    [320, 392) 'henc'
    [448, 457) 'bufSample2'
    [512, 567) 'bufSample1'
    [608, 688) 'bufSample3'
    [736, 836) 'a' <== Memory access at offset 836 overflows this variable
    [896, 2944) 'out'
    [2976, 11168) 'respBuf'
HINT: this may be a false positive if your program uses some custom stack unwind mechanism or swapcontext
      (longjmp and C++ exceptions *are* supported)
SUMMARY: AddressSanitizer: stack-buffer-overflow /tmp/ls-hpack/test/test_hpack.c:457 in test_hpack_test_RFC_Example
Shadow bytes around the buggy address:
  0x10003d2ab7e0: f2 f2 f2 f2 f2 f2 00 f2 f2 f2 f2 f2 f2 f2 00 00
  0x10003d2ab7f0: 00 00 00 f2 f2 f2 f2 f2 f2 f2 00 00 00 00 00 00
  0x10003d2ab800: 00 00 00 f2 f2 f2 f2 f2 f2 f2 00 01 f2 f2 f2 f2
  0x10003d2ab810: f2 f2 00 00 00 00 00 00 07 f2 f2 f2 f2 f2 00 00
  0x10003d2ab820: 00 00 00 00 00 00 00 00 f2 f2 f2 f2 f2 f2 00 00
=>0x10003d2ab830: 00 00 00 00 00 00 00 00 00 00[04]f2 f2 f2 f2 f2
  0x10003d2ab840: f2 f2 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x10003d2ab850: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x10003d2ab860: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x10003d2ab870: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x10003d2ab880: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
==6199==ABORTING
 
So nobody can commit code if there is memory leak or corrupt.
Current library state is perfect and neither leaks not corrupts detected so I had to add several issues to code to make sure sanitizer works