### PR TITLE
portability patches

### DIFF
--- a/deps/xxhash/xxhash.c
+++ b/deps/xxhash/xxhash.c
@@ -543,7 +543,7 @@ XXH_errorcode XXH32_freeState(XXH32_state_t *statePtr)
 {
     XXH_free(statePtr);
     return XXH_OK;
-};
+}
 
 XXH64_state_t *XXH64_createState(void)
 {
@@ -555,7 +555,7 @@ XXH_errorcode XXH64_freeState(XXH64_state_t *statePtr)
 {
     XXH_free(statePtr);
     return XXH_OK;
-};
+}
 
 
 /*** Hash feed ***/

--- a/lshpack.c
+++ b/lshpack.c
@@ -251,7 +251,7 @@ struct lshpack_enc_table_entry
     unsigned                        ete_name_hash;
     unsigned                        ete_name_len;
     unsigned                        ete_val_len;
-    char                            ete_buf[0];
+    char                            ete_buf[];
 };
 
 #define ETE_NAME(ete) ((ete)->ete_buf)
@@ -1234,7 +1234,7 @@ struct dec_table_entry
     }           dte_flags:8;
 #endif
     uint8_t     dte_name_idx;
-    char        dte_buf[0];     /* Contains both name and value */
+    char        dte_buf[];     /* Contains both name and value */
 };
 
 #define DTE_NAME(dte) ((dte)->dte_buf)

--- a/lshpack.h
+++ b/lshpack.h
@@ -213,6 +213,18 @@ lshpack_dec_set_max_capacity (struct lshpack_dec *, unsigned);
 
 #include <sys/queue.h>
 
+#ifdef __OpenBSD__
+#define STAILQ_HEAD             SIMPLEQ_HEAD
+#define STAILQ_ENTRY            SIMPLEQ_ENTRY
+#define STAILQ_INIT             SIMPLEQ_INIT
+#define STAILQ_INSERT_TAIL      SIMPLEQ_INSERT_TAIL
+#define STAILQ_EMPTY            SIMPLEQ_EMPTY
+#define STAILQ_FIRST            SIMPLEQ_FIRST
+#define STAILQ_NEXT             SIMPLEQ_NEXT
+#define STAILQ_REMOVE_HEAD      SIMPLEQ_REMOVE_HEAD
+#define STAILQ_FOREACH          SIMPLEQ_FOREACH
+#endif
+
 struct lshpack_enc_table_entry;
 
 STAILQ_HEAD(lshpack_enc_head, lshpack_enc_table_entry);

--- a/lshpack.h
+++ b/lshpack.h
@@ -31,7 +31,7 @@ extern "C" {
 
 #include <limits.h>
 #include <stdint.h>
-#include <lsxpack_header.h>
+#include "lsxpack_header.h"
 
 #define LSHPACK_MAJOR_VERSION 2
 #define LSHPACK_MINOR_VERSION 2


### PR DESCRIPTION
portability patches

* attempt local include before system path
* STAILQ_* -> SIMPLEQ_* on OpenBSD
* use C99 flexible array member
* remove stray semi-colons
