### PR TITLE
provide STAILQ_FOREACH

### DIFF
--- a/lshpack.h
+++ b/lshpack.h
@@ -225,6 +225,13 @@ lshpack_dec_set_max_capacity (struct lshpack_dec *, unsigned);
 #define STAILQ_FOREACH          SIMPLEQ_FOREACH
 #endif
 
+#ifndef STAILQ_FOREACH
+#define STAILQ_FOREACH(var, head, field)                                \
+        for((var) = STAILQ_FIRST((head));                               \
+           (var);                                                       \
+           (var) = STAILQ_NEXT((var), field))
+#endif
+
 struct lshpack_enc_table_entry;
 
 STAILQ_HEAD(lshpack_enc_head, lshpack_enc_table_entry);


### PR DESCRIPTION
Provide a definition for STAILQ_FOREACH if it is not available after importing `sys/queue.h`, as with legacy systems. Fixes ls-hpack build on OS X 10.4 when building as part of lighttpd.