### PR TITLE
misplaced macro

### DIFF
--- a/lshpack.c
+++ b/lshpack.c
@@ -800,8 +800,8 @@ lshpack_enc_huff_encode (const unsigned char *src,
         case 6: *p_dst++ = bits >> 40;
         FALL_THROUGH;
         case 5: *p_dst++ = bits >> 32;
-#endif
         FALL_THROUGH;
+#endif
         case 4: *p_dst++ = bits >> 24;
         FALL_THROUGH;
         case 3: *p_dst++ = bits >> 16;


### PR DESCRIPTION
On 32-bit, the `FALL_THROUGH;` macro in the switch statement should be inside the pre-processor conditional.
```
--- a/lshpack.c
+++ b/lshpack.c
@@ -800,8 +800,8 @@ lshpack_enc_huff_encode (const unsigned char *src,
         case 6: *p_dst++ = bits >> 40;
         FALL_THROUGH;
         case 5: *p_dst++ = bits >> 32;
-#endif
         FALL_THROUGH;
+#endif
         case 4: *p_dst++ = bits >> 24;
         FALL_THROUGH;
         case 3: *p_dst++ = bits >> 16;
```