### PR TITLE
Fix: allow empty names as well as name with trailing whitespace

### DIFF
--- a/lshpack.c
+++ b/lshpack.c
@@ -23,7 +23,6 @@ SOFTWARE.
 */
 
 #include <assert.h>
-#include <ctype.h>
 #include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
@@ -1787,11 +1786,6 @@ lshpack_dec_decode (struct lshpack_dec *dec,
         }
         if (len > UINT16_MAX)
             return LSHPACK_ERR_TOO_LARGE;
-        while(len > 0 && isspace(*(name + len - 1)))
-            --len;
-        if (len == 0)
-            return LSHPACK_ERR_BAD_DATA;
-
 #if LSHPACK_DEC_CALC_HASH
         output->flags |= LSXPACK_NAME_HASH;
         output->name_hash = XXH32(name, (size_t) len, LSHPACK_XXH_SEED);

--- a/test/test_hpack.c
+++ b/test/test_hpack.c
@@ -603,6 +603,68 @@ test_decode_limits (void)
 
 
 static void
+test_hdec_zero_length_name (void)
+{
+    const unsigned char input[] = {
+        0x00,       /* Literal header field without indexing: new name */
+        0x00,       /* Name length */
+        0x05, 'v', 'a', 'l', 'u', 'e',
+    };
+    const unsigned char *src;
+    char out[0x100];
+    struct lshpack_dec hdec;
+    struct lsxpack_header xhdr;
+    int s;
+
+    lshpack_dec_init(&hdec);
+
+    src = input;
+    lsxpack_header_prepare_decode(&xhdr, out, 0, sizeof(out));
+    s = lshpack_dec_decode(&hdec, &src, input + sizeof(input), &xhdr);
+    assert(0 == s);
+    assert(src == input + sizeof(input));
+    assert(0 == xhdr.name_len);
+    assert(5 == xhdr.val_len);
+    assert(NULL == lsxpack_header_get_name(&xhdr));
+    assert(0 == memcmp(lsxpack_header_get_value(&xhdr), "value", 5));
+
+    lshpack_dec_cleanup(&hdec);
+}
+
+
+static void
+test_hdec_trailing_whitespace_name (void)
+{
+    static const char name[] = "cookie \t\v\f\r\n";
+    const unsigned char input[] = {
+        0x00,       /* Literal header field without indexing: new name */
+        sizeof(name) - 1,
+        'c', 'o', 'o', 'k', 'i', 'e', ' ', '\t', '\v', '\f', '\r', '\n',
+        0x05, 'v', 'a', 'l', 'u', 'e',
+    };
+    const unsigned char *src;
+    char out[0x100];
+    struct lshpack_dec hdec;
+    struct lsxpack_header xhdr;
+    int s;
+
+    lshpack_dec_init(&hdec);
+
+    src = input;
+    lsxpack_header_prepare_decode(&xhdr, out, 0, sizeof(out));
+    s = decode_and_check_hashes(&hdec, &src, input + sizeof(input), &xhdr);
+    assert(0 == s);
+    assert(src == input + sizeof(input));
+    assert(sizeof(name) - 1 == xhdr.name_len);
+    assert(5 == xhdr.val_len);
+    assert(0 == memcmp(lsxpack_header_get_name(&xhdr), name, sizeof(name) - 1));
+    assert(0 == memcmp(lsxpack_header_get_value(&xhdr), "value", 5));
+
+    lshpack_dec_cleanup(&hdec);
+}
+
+
+static void
 test_hpack_self_enc_dec_test (void)
 {
     unsigned char respBuf[8192] = {0};
@@ -1636,6 +1698,8 @@ main (int argc, char **argv)
 #endif
     test_hdec_static_idx_0();
     test_hdec_boundary();
+    test_hdec_zero_length_name();
+    test_hdec_trailing_whitespace_name();
 
     return 0;
 }

--- a/test/test_hpack.c
+++ b/test/test_hpack.c
@@ -1362,7 +1362,7 @@ test_header_arr (void)
 static void
 insert_long_codes_into_header_arr (void)
 {
-    const char codes[] = "\\\x16\x7F\x06";
+    const char codes[] = "\\\x16\x7F\x09";
     unsigned code_count, i, name, pos, off;
     char *dst;
     size_t len;


### PR DESCRIPTION
This change is a relatively recent regression.  Added tests
to guard against future regressions.

Closes #22